### PR TITLE
feat: update cafleet to 0.23.4

### DIFF
--- a/Formula/cafleet.rb
+++ b/Formula/cafleet.rb
@@ -1,15 +1,15 @@
 class Cafleet < Formula
   desc "Coding agent orchestrator for multi-agents collaboration across coding agent providers"
   homepage "https://github.com/himkt/cafleet"
-  url "https://github.com/himkt/cafleet/archive/refs/tags/0.23.3.tar.gz"
-  sha256 "84c2cc32a8d689888d0221979a10e3dfd39271811d0d1498534ca82219aa360e"
+  url "https://github.com/himkt/cafleet/archive/refs/tags/0.23.4.tar.gz"
+  sha256 "c860193abecc2c0e08cab5530f00693af3b8142545d9102e4db59ac1822acb10"
   license "MIT"
 
   bottle do
-    root_url "https://github.com/himkt/cafleet/releases/download/0.23.3"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma: "c262cda9480265d6328311e42b6d5fc0e07455cb597eb8d13aaa321bda31f888"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "793659240a737d6a979fd55a9df0892cca24baabb19cacdad291de8e96bd9bd6"
-    sha256 cellar: :any_skip_relocation, arm64_linux:  "4cec5e837153591150a2b4535bdd35fadff87120197a20bc5a2f8d1334aa1ddd"
+    root_url "https://github.com/himkt/cafleet/releases/download/0.23.4"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma: "59ec6bab9e3d182add098bd3aa12689f5b0a66006135d36458c66f4d22709421"
+    sha256 cellar: :any_skip_relocation, x86_64_linux: "ceb5067f3b4c5b83cb576ae9adc06e76a6010452f58ce9310c79eb4bc9184530"
+    sha256 cellar: :any_skip_relocation, arm64_linux:  "dc4757a2f49dec47a5a188ea50d0bb36d57341a44b7f4c076ed02b8e1b4585d6"
   end
 
   # mise.toml pins the whole toolchain (node, pnpm, rust, zig), so it is the only build dep

--- a/api/cask/voicevox.json
+++ b/api/cask/voicevox.json
@@ -61,7 +61,7 @@
   "sha256": "69e4cf9afb6d5602f821f45d09dfb95d08b56edeee5693b34ab249db18a8c902",
   "skip_livecheck": false,
   "tap": "himkt/tap",
-  "tap_git_head": "b1695464efa222fc0c9f948fa2029af65bd83856",
+  "tap_git_head": "a88b36fcae321d1705b8a076b42c7692ade79df6",
   "token": "voicevox",
   "url": "https://github.com/VOICEVOX/voicevox/releases/download/0.25.0/VOICEVOX.0.25.0-arm64.dmg",
   "url_specs": {},

--- a/api/formula/cafleet.json
+++ b/api/formula/cafleet.json
@@ -4,22 +4,22 @@
   "bottle": {
     "stable": {
       "rebuild": 0,
-      "root_url": "https://github.com/himkt/cafleet/releases/download/0.23.3",
+      "root_url": "https://github.com/himkt/cafleet/releases/download/0.23.4",
       "files": {
         "arm64_sonoma": {
           "cellar": ":any_skip_relocation",
-          "url": "https://github.com/himkt/cafleet/releases/download/0.23.3/cafleet-0.23.3.arm64_sonoma.bottle.tar.gz",
-          "sha256": "c262cda9480265d6328311e42b6d5fc0e07455cb597eb8d13aaa321bda31f888"
+          "url": "https://github.com/himkt/cafleet/releases/download/0.23.4/cafleet-0.23.4.arm64_sonoma.bottle.tar.gz",
+          "sha256": "59ec6bab9e3d182add098bd3aa12689f5b0a66006135d36458c66f4d22709421"
         },
         "x86_64_linux": {
           "cellar": ":any_skip_relocation",
-          "url": "https://github.com/himkt/cafleet/releases/download/0.23.3/cafleet-0.23.3.x86_64_linux.bottle.tar.gz",
-          "sha256": "793659240a737d6a979fd55a9df0892cca24baabb19cacdad291de8e96bd9bd6"
+          "url": "https://github.com/himkt/cafleet/releases/download/0.23.4/cafleet-0.23.4.x86_64_linux.bottle.tar.gz",
+          "sha256": "ceb5067f3b4c5b83cb576ae9adc06e76a6010452f58ce9310c79eb4bc9184530"
         },
         "arm64_linux": {
           "cellar": ":any_skip_relocation",
-          "url": "https://github.com/himkt/cafleet/releases/download/0.23.3/cafleet-0.23.3.arm64_linux.bottle.tar.gz",
-          "sha256": "4cec5e837153591150a2b4535bdd35fadff87120197a20bc5a2f8d1334aa1ddd"
+          "url": "https://github.com/himkt/cafleet/releases/download/0.23.4/cafleet-0.23.4.arm64_linux.bottle.tar.gz",
+          "sha256": "dc4757a2f49dec47a5a188ea50d0bb36d57341a44b7f4c076ed02b8e1b4585d6"
         }
       }
     }
@@ -64,21 +64,21 @@
   "requirements": [],
   "revision": 0,
   "ruby_source_checksum": {
-    "sha256": "f3c3b8f3435f519ed20269bc9ffc1bdf554de4c799585a9c8be1beceb78a5abc"
+    "sha256": "2d31c7352b488233e3a9510e484ea0af3aa41c4d944233eed0ee5ab98d2fa3d6"
   },
   "ruby_source_path": "Formula/cafleet.rb",
   "service": null,
   "skip_livecheck": false,
   "tap": "himkt/tap",
-  "tap_git_head": "b1695464efa222fc0c9f948fa2029af65bd83856",
+  "tap_git_head": "a88b36fcae321d1705b8a076b42c7692ade79df6",
   "test_dependencies": [],
   "urls": {
     "stable": {
-      "url": "https://github.com/himkt/cafleet/archive/refs/tags/0.23.3.tar.gz",
+      "url": "https://github.com/himkt/cafleet/archive/refs/tags/0.23.4.tar.gz",
       "tag": null,
       "revision": null,
       "using": null,
-      "checksum": "84c2cc32a8d689888d0221979a10e3dfd39271811d0d1498534ca82219aa360e"
+      "checksum": "c860193abecc2c0e08cab5530f00693af3b8142545d9102e4db59ac1822acb10"
     }
   },
   "uses_from_macos": [],
@@ -87,7 +87,7 @@
   "version_scheme": 0,
   "versioned_formulae": [],
   "versions": {
-    "stable": "0.23.3",
+    "stable": "0.23.4",
     "head": null,
     "bottle": true
   }

--- a/api/formula/pathfinder.json
+++ b/api/formula/pathfinder.json
@@ -75,7 +75,7 @@
   "service": null,
   "skip_livecheck": false,
   "tap": "himkt/tap",
-  "tap_git_head": "b1695464efa222fc0c9f948fa2029af65bd83856",
+  "tap_git_head": "a88b36fcae321d1705b8a076b42c7692ade79df6",
   "test_dependencies": [],
   "urls": {
     "stable": {


### PR DESCRIPTION
## Summary

- update the CAFleet source archive to 0.23.4
- update bottle URLs and SHA-256 checksums for macOS ARM and Linux
- regenerate Homebrew API metadata

## Verification

- verified the source archive SHA-256 checksum
- verified the x86_64 Linux bottle checksum and `cafleet --version` output
- validated Ruby syntax and generated JSON
- ran `git diff --check`